### PR TITLE
Refactored to use FluentLoggerFactory

### DIFF
--- a/src/main/java/org/fluentd/logger/FluentLoggerFactory.java
+++ b/src/main/java/org/fluentd/logger/FluentLoggerFactory.java
@@ -1,0 +1,105 @@
+//
+// A Structured Logger for Fluent
+//
+// Copyright (C) 2011 - 2012 OZAWA Tsuyoshi
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.fluentd.logger;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.Properties;
+import java.util.WeakHashMap;
+
+import org.fluentd.logger.sender.RawSocketSender;
+import org.fluentd.logger.sender.Sender;
+
+public class FluentLoggerFactory {
+
+    private final Map<String, FluentLogger> loggers;
+
+    public FluentLoggerFactory() {
+        loggers = new WeakHashMap<String, FluentLogger>();
+    }
+
+    public FluentLogger getLogger(String tag) {
+        return getLogger(tag, "localhost", 24224);
+    }
+
+    public FluentLogger getLogger(String tag, String host, int port) {
+        return getLogger(tag, host, port, 3 * 1000, 1 * 1024 * 1024);
+    }
+
+    public synchronized FluentLogger getLogger(
+            String tag, String host, int port, int timeout, int bufferCapacity) {
+        String key = String.format("%s_%s_%d_%d_%d",
+                new Object[] { tag, host, port, timeout, bufferCapacity });
+        if (loggers.containsKey(key)) {
+            return loggers.get(key);
+        } else {
+            Sender sender = null;
+            Properties props = System.getProperties();
+            if (!props.containsKey(Config.FLUENT_SENDER_CLASS)) {
+                // create default sender object
+                sender = new RawSocketSender(host, port, timeout, bufferCapacity);
+            } else {
+                String senderClassName = props.getProperty(Config.FLUENT_SENDER_CLASS);
+                try {
+                    sender = createSenderInstance(senderClassName,
+                            new Object[] { host, port, timeout, bufferCapacity });
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            FluentLogger logger = new FluentLogger(tag, sender);
+            loggers.put(key, logger);
+            return logger;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Sender createSenderInstance(final String className,
+            final Object[] params) throws ClassNotFoundException, SecurityException,
+            NoSuchMethodException, IllegalArgumentException, InstantiationException,
+            IllegalAccessException, InvocationTargetException {
+        Class<Sender> cl = (Class<Sender>)
+                FluentLogger.class.getClassLoader().loadClass(className);
+        Constructor<Sender> cons = cl.getDeclaredConstructor(
+                new Class[] { String.class, int.class, int.class, int.class });
+        return (Sender) cons.newInstance(params);
+    }
+
+    /**
+     * the method is for testing
+     */
+    Map<String, FluentLogger> getLoggers() {
+        return loggers;
+    }
+
+    public synchronized void closeAll() {
+        for (FluentLogger logger : loggers.values()) {
+            logger.close();
+        }
+        loggers.clear();
+    }
+
+    public synchronized void flushAll() {
+        for (FluentLogger logger : loggers.values()) {
+            logger.flush();
+        }
+    }
+
+}
+


### PR DESCRIPTION
Currently, FluentLogger instances are managed by static members and methods in FluentLogger class itself. This make it difficult to delegate the management of the instances from the other JVM languages(e.g. Scala). In this patch, the management of the instances are moved to FluentLoggerFactory to avoid the problem.

Signed-off-by: OZAWA Tsuyoshi ozawa.tsuyoshi@gmail.com
