### PR TITLE
Missing timeout initialization in RawSocketSender

### DIFF
--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -63,6 +63,7 @@ public class RawSocketSender implements Sender {
         server = new InetSocketAddress(host, port);
         reconnector = new ExponentialDelayReconnector();
         name = String.format("%s_%d_%d_%d", host, port, timeout, bufferCapacity);
+        this.timeout = timeout;
         open();
     }
 


### PR DESCRIPTION
Constructor uses "timeout" just to build the "name", but never assigns the "timeout" member variable to the passed value in the constructor, and thus timeout is always 0 (default for int).

Please consider this fix.
