### PR TITLE
Do not force projects to use logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.1.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
The point of using slf4j is that any implementation of could be used. Forcing logback is counter productive as it will require developers to exclude that dependency.

Instead, use this dependency only during the execution of the tests (because an implementation should be provided).
