### PR TITLE
fix emit() behavior to return false if an error occurred

### DIFF
--- a/src/main/java/org/fluentd/logger/FluentLogger.java
+++ b/src/main/java/org/fluentd/logger/FluentLogger.java
@@ -128,4 +128,8 @@ public class FluentLogger {
             sender.close();
         }
     }
+
+    public boolean isConnected() {
+        return sender != null && sender.isConnected();
+    }
 }

--- a/src/main/java/org/fluentd/logger/sender/NullSender.java
+++ b/src/main/java/org/fluentd/logger/sender/NullSender.java
@@ -50,4 +50,9 @@ public class NullSender implements Sender {
     public String toString() {
         return this.getClass().getName();
     }
+
+    @Override
+    public boolean isConnected() {
+        return true;
+    }
 }

--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -211,4 +211,9 @@ public class RawSocketSender implements Sender {
     public String toString() {
         return getName();
     }
+
+    @Override
+    public boolean isConnected() {
+        return socket != null && !socket.isClosed() && socket.isConnected() && !socket.isOutputShutdown();
+    }
 }

--- a/src/main/java/org/fluentd/logger/sender/Sender.java
+++ b/src/main/java/org/fluentd/logger/sender/Sender.java
@@ -29,4 +29,6 @@ public interface Sender {
     void close();
 
     String getName();
+
+    boolean isConnected();
 }


### PR DESCRIPTION
fix testReconnectAfterBufferFull() test to flush at the end, rather then emit a new event and then flush.  this only affects the number of events checked at the end.
