### PR TITLE
Update the quickstart code to fix compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following program is a small example of Fluent Logger for Java.
 
         public void doApplicationLogic() {
             // ...
-            Map<String, String> data = new HashMap<String, String>();
+            Map<String, Object> data = new HashMap<String, Object>();
             data.put("from", "userA");
             data.put("to", "userB");
             LOG.log("follow", data);


### PR DESCRIPTION
The quickstart code in README causes compilation error as follows.

```
error: incompatible types: Map<String,String> cannot be converted to Map<String,Object>
        LOG.log("follow", data);
                          ^
```

I've replaced String with Object.