### PR TITLE
Bug fix buffer emptied on IO exception

### DIFF
--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -186,6 +186,7 @@ public class RawSocketSender implements Sender {
             clearBuffer();
             reconnector.clearErrorHistory();
         } catch (IOException e) {
+            pendings.reset(); // reset to old position in case of IO error
             try {
                 errorHandler.handleNetworkError(e);
             }
@@ -200,6 +201,7 @@ public class RawSocketSender implements Sender {
 
     synchronized byte[] getBuffer() {
         int len = pendings.position();
+        pendings.mark(); // mark old position in case of IO error
         pendings.position(0);
         byte[] ret = new byte[len];
         pendings.get(ret, 0, len);

--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -78,13 +78,9 @@ public class RawSocketSender implements Sender {
     }
 
     private void connect() throws IOException {
-        try {
-            socket = new Socket();
-            socket.connect(server, timeout);
-            out = new BufferedOutputStream(socket.getOutputStream());
-        } catch (IOException e) {
-            throw e;
-        }
+        socket = new Socket();
+        socket.connect(server, timeout);
+        out = new BufferedOutputStream(socket.getOutputStream());
     }
 
     private void reconnect() throws IOException {
@@ -131,10 +127,10 @@ public class RawSocketSender implements Sender {
 
     protected boolean emit(Event event) {
         if (LOG.isTraceEnabled()) {
-            LOG.trace(String.format("Created %s", new Object[]{event}));
+            LOG.trace("Created {}", event);
         }
 
-        byte[] bytes = null;
+        byte[] bytes;
         try {
             // serialize tag, timestamp and data
             bytes = msgpack.write(event);


### PR DESCRIPTION
If RawSocketSender encounters an IO error, the memory buffer remains in an emptied status because getBuffer() sets position to 0. All the buffered logs are lost.

This fix marks the end of the buffer and resets to that value in case of IOException.