### PR TITLE
fix second/millis confusion

### DIFF
--- a/src/main/java/org/fluentd/logger/sender/ConstantDelayReconnector.java
+++ b/src/main/java/org/fluentd/logger/sender/ConstantDelayReconnector.java
@@ -7,7 +7,7 @@ import java.util.Deque;
 import java.util.LinkedList;
 
 /**
- * Calculate exponential delay for reconnecting
+ * Handles constant delay for reconnecting. The default delay is 50 ms.
  */
 public class ConstantDelayReconnector implements Reconnector {
     private static final Logger LOG = LoggerFactory.getLogger(ConstantDelayReconnector.class);

--- a/src/main/java/org/fluentd/logger/sender/ExponentialDelayReconnector.java
+++ b/src/main/java/org/fluentd/logger/sender/ExponentialDelayReconnector.java
@@ -1,8 +1,5 @@
 package org.fluentd.logger.sender;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.LinkedList;
 
 /**
@@ -10,11 +7,11 @@ import java.util.LinkedList;
  */
 public class ExponentialDelayReconnector implements Reconnector {
 
-    private double wait = 0.5;
+    private double waitMillis = 50; // Start wait is 50ms
 
     private double waitIncrRate = 1.5;
 
-    private double waitMax = 60;
+    private double waitMaxMillis = 60 * 1000; // Max wait is 1 minute
 
     private int waitMaxCount;
 
@@ -26,7 +23,7 @@ public class ExponentialDelayReconnector implements Reconnector {
     }
 
     private int getWaitMaxCount() {
-        double r = waitMax / wait;
+        double r = waitMaxMillis / waitMillis;
         for (int j = 1; j <= 100; j++) {
             if (r < waitIncrRate) {
                 return j + 1;
@@ -57,13 +54,13 @@ public class ExponentialDelayReconnector implements Reconnector {
             return true;
         }
 
-        double suppressSec;
+        double suppressMillis;
         if (size < waitMaxCount) {
-            suppressSec = wait * Math.pow(waitIncrRate, size - 1);
+            suppressMillis = waitMillis * Math.pow(waitIncrRate, size - 1);
         } else {
-            suppressSec = waitMax;
+            suppressMillis = waitMaxMillis;
         }
 
-        return (!(timestamp - errorHistory.getLast() < suppressSec));
+        return (timestamp - errorHistory.getLast()) > suppressMillis;
     }
 }

--- a/src/main/java/org/fluentd/logger/sender/ExponentialDelayReconnector.java
+++ b/src/main/java/org/fluentd/logger/sender/ExponentialDelayReconnector.java
@@ -3,7 +3,8 @@ package org.fluentd.logger.sender;
 import java.util.LinkedList;
 
 /**
- * Calcurate exponential delay for reconnecting
+ * Calculates exponential delay for reconnecting. The start delay is 50ms and exponentionally grows to max 60 seconds in
+ * function of the number of connection errors.
  */
 public class ExponentialDelayReconnector implements Reconnector {
 
@@ -61,6 +62,6 @@ public class ExponentialDelayReconnector implements Reconnector {
             suppressMillis = waitMaxMillis;
         }
 
-        return (timestamp - errorHistory.getLast()) > suppressMillis;
+        return (timestamp - errorHistory.getLast()) >= suppressMillis;
     }
 }

--- a/src/main/java/org/fluentd/logger/sender/ExponentialDelayReconnector.java
+++ b/src/main/java/org/fluentd/logger/sender/ExponentialDelayReconnector.java
@@ -3,7 +3,7 @@ package org.fluentd.logger.sender;
 import java.util.LinkedList;
 
 /**
- * Calculates exponential delay for reconnecting. The start delay is 50ms and exponentionally grows to max 60 seconds in
+ * Calculates exponential delay for reconnecting. The start delay is 50ms and exponentially grows to max 60 seconds in
  * function of the number of connection errors.
  */
 public class ExponentialDelayReconnector implements Reconnector {


### PR DESCRIPTION
I noticed the ExponentialDelayReconnector always returns true for enableReconnection. I think the code confuses the timestamp in milliseconds and the wait time expressed in seconds