### PR TITLE
Handle buffer overflow errors

### DIFF
--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -165,6 +165,10 @@ public class RawSocketSender implements Sender {
                 LOG.error("Cannot send logs to " + server.toString());
                 return false;
             }
+            if (bytes.length > pendings.capacity()) {
+                LOG.error("Log data larger {} than buffer size {}", bytes.length, pendings.capacity());
+                return false;
+            }
         }
         pendings.put(bytes);
 

--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -34,7 +34,7 @@ public class RawSocketSender implements Sender {
 
     private static final Logger LOG = LoggerFactory.getLogger(RawSocketSender.class);
 
-    private static final ErrorHandler DEFAULT_ERROR_HANLDER = new ErrorHandler() {};
+    private static final ErrorHandler DEFAULT_ERROR_HANDLER = new ErrorHandler() {};
 
     private MessagePack msgpack;
 
@@ -52,7 +52,7 @@ public class RawSocketSender implements Sender {
 
     private String name;
 
-    private ErrorHandler errorHandler = DEFAULT_ERROR_HANLDER;
+    private ErrorHandler errorHandler = DEFAULT_ERROR_HANDLER;
 
     public RawSocketSender() {
         this("localhost", 24224);
@@ -244,6 +244,6 @@ public class RawSocketSender implements Sender {
 
     @Override
     public void removeErrorHandler() {
-        this.errorHandler = DEFAULT_ERROR_HANLDER;
+        this.errorHandler = DEFAULT_ERROR_HANDLER;
     }
 }

--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -165,8 +165,8 @@ public class RawSocketSender implements Sender {
                 LOG.error("Cannot send logs to " + server.toString());
                 return false;
             }
-            if (bytes.length > pendings.capacity()) {
-                LOG.error("Log data larger {} than buffer size {}", bytes.length, pendings.capacity());
+            if (bytes.length > pendings.remaining()) {
+                LOG.error("Log data {} larger than remaining buffer size {}", bytes.length, pendings.remaining());
                 return false;
             }
         }

--- a/src/test/java/org/fluentd/logger/sender/TestRawSocketSender.java
+++ b/src/test/java/org/fluentd/logger/sender/TestRawSocketSender.java
@@ -12,10 +12,7 @@ import java.io.BufferedInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.Socket;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -411,5 +408,55 @@ public class TestRawSocketSender {
         // check data
         assertEquals(0, bufferFull.getCount());
         assertEquals(i, elist.size());
+    }
+
+    @Test
+    public void testBufferOverflow() throws Exception {
+        // start mock fluentd
+        int port = MockFluentd.randomPort();
+        MockFluentd fluentd = new MockFluentd(port, new MockFluentd.MockProcess() {
+            public void process(MessagePack msgpack, Socket socket) throws IOException {
+                BufferedInputStream in = new BufferedInputStream(socket.getInputStream());
+                try {
+                    Unpacker unpacker = msgpack.createUnpacker(in);
+                    while (true) {
+                        unpacker.read(Event.class);
+                    }
+                    //socket.close();
+                } catch (EOFException e) {
+                    // ignore
+                }
+            }
+        });
+        fluentd.start();
+
+        // start senders
+        Sender sender = new RawSocketSender("localhost", port, 3000, 256);
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put("large", randomString(512));
+        boolean success = sender.emit("tag.label1", data);
+        assertFalse(success);
+
+        // close sender sockets
+        sender.close();
+        // close mock server sockets
+        fluentd.close();
+    }
+
+    private static final String CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ ";
+
+    private String randomString(int len) {
+        StringBuilder sb = new StringBuilder(len);
+
+        Random rnd = new Random();
+        for (int i = 0; i < len; i++) {
+            if (i != 0 && i % 128 == 0) {
+                sb.append("\r\n");
+            }
+
+            sb.append(CHARS.charAt(rnd.nextInt(CHARS.length())));
+        }
+
+        return sb.toString();
     }
 }


### PR DESCRIPTION
When the log message is larger then the buffer size, a java.nio.BufferOverflowException is generated.
This PR handles the error condition the same way as messages which cannot be added to the buffer.
