### PR TITLE
Reduce error logging if reconnect is disabled (#16).

### DIFF
--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -152,6 +152,8 @@ public class RawSocketSender implements Sender {
             flush();
             if (pendings.position() == 0) {
                 return true;
+            } else {
+                LOG.error("Cannot send logs to " + server.toString());
             }
         }
 
@@ -162,7 +164,6 @@ public class RawSocketSender implements Sender {
         // buffering
         if (pendings.position() + bytes.length > pendings.capacity()) {
             if (!flushBuffer()) {
-                LOG.error("Cannot send logs to " + server.toString());
                 return false;
             }
         }


### PR DESCRIPTION
#16 reduce error logging if reconnect is disabled.  Move the log message inside the reconnect if statement so it is only printed when reconnects are actually tried.