### PR TITLE
DNS lookup is done on every reconnect attempt

### DIFF
--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -26,7 +26,6 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
@@ -37,8 +36,6 @@ public class RawSocketSender implements Sender {
     private static final ErrorHandler DEFAULT_ERROR_HANDLER = new ErrorHandler() {};
 
     private MessagePack msgpack;
-
-    private SocketAddress server;
 
     private Socket socket;
 
@@ -52,9 +49,9 @@ public class RawSocketSender implements Sender {
 
     private String name;
 
-    private String host;
+    private final String host;
 
-    private int port;
+    private final int port;
 
     private ErrorHandler errorHandler = DEFAULT_ERROR_HANDLER;
 
@@ -77,7 +74,6 @@ public class RawSocketSender implements Sender {
         pendings = ByteBuffer.allocate(bufferCapacity);
         this.host = host;
         this.port = port;
-        server = new InetSocketAddress(host, port);
         this.reconnector = reconnector;
         name = String.format("%s_%d_%d_%d", host, port, timeout, bufferCapacity);
         this.timeout = timeout;
@@ -86,8 +82,7 @@ public class RawSocketSender implements Sender {
     private void connect() throws IOException {
         try {
             socket = new Socket();
-            server = new InetSocketAddress(host, port);
-            socket.connect(server, timeout);
+            socket.connect(new InetSocketAddress(host, port), timeout);
             out = new BufferedOutputStream(socket.getOutputStream());
         } catch (IOException e) {
             throw e;
@@ -160,7 +155,7 @@ public class RawSocketSender implements Sender {
             if (pendings.position() == 0) {
                 return true;
             } else {
-                LOG.error("Cannot send logs to " + server.toString());
+                LOG.error("Cannot send logs to " + socket.getInetAddress().toString());
             }
         }
 

--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -52,6 +52,10 @@ public class RawSocketSender implements Sender {
 
     private String name;
 
+    private String host;
+
+    private int port;
+
     private ErrorHandler errorHandler = DEFAULT_ERROR_HANDLER;
 
     public RawSocketSender() {
@@ -71,6 +75,8 @@ public class RawSocketSender implements Sender {
         msgpack = new MessagePack();
         msgpack.register(Event.class, Event.EventTemplate.INSTANCE);
         pendings = ByteBuffer.allocate(bufferCapacity);
+        this.host = host;
+        this.port = port;
         server = new InetSocketAddress(host, port);
         this.reconnector = reconnector;
         name = String.format("%s_%d_%d_%d", host, port, timeout, bufferCapacity);
@@ -80,6 +86,7 @@ public class RawSocketSender implements Sender {
     private void connect() throws IOException {
         try {
             socket = new Socket();
+            server = new InetSocketAddress(host, port);
             socket.connect(server, timeout);
             out = new BufferedOutputStream(socket.getOutputStream());
         } catch (IOException e) {


### PR DESCRIPTION
DNS lookup is done on every reconnect attempt. Caching the machine address for the lifetime of the application is problematic in a dynamic environment like docker containers. If the machine address changes, applications need to be restarted to pick up the correct address and log correctly.