### PR TITLE
Bugfix for issue #64; purge closed loggers from factory cache

### DIFF
--- a/src/main/java/org/fluentd/logger/FluentLogger.java
+++ b/src/main/java/org/fluentd/logger/FluentLogger.java
@@ -112,6 +112,7 @@ public class FluentLogger {
             sender.close();
             sender = null;
         }
+        factory.purgeLogger(this);
     }
 
     public String getName() {

--- a/src/main/java/org/fluentd/logger/FluentLoggerFactory.java
+++ b/src/main/java/org/fluentd/logger/FluentLoggerFactory.java
@@ -19,6 +19,7 @@ package org.fluentd.logger;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -112,7 +113,7 @@ public class FluentLoggerFactory {
     }
 
     public synchronized void closeAll() {
-        for (FluentLogger logger : loggers.keySet()) {
+        for (FluentLogger logger : new ArrayList<FluentLogger>(loggers.keySet())) {
             logger.close();
         }
         loggers.clear();

--- a/src/main/java/org/fluentd/logger/FluentLoggerFactory.java
+++ b/src/main/java/org/fluentd/logger/FluentLoggerFactory.java
@@ -19,7 +19,9 @@ package org.fluentd.logger;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.WeakHashMap;
 
@@ -79,6 +81,18 @@ public class FluentLoggerFactory {
         loggers.put(logger, key);
         return logger;
     }
+
+    /** Purges an invalid logger from the cache.
+     */
+	protected synchronized void purgeLogger(FluentLogger logger) {
+		Iterator<Entry<FluentLogger, String>> it = loggers.entrySet().iterator();
+		while (it.hasNext()) {
+			if (it.next().getKey() == logger) {
+				it.remove();
+				return;
+			}
+		}
+	}
 
     @SuppressWarnings("unchecked")
     private Sender createSenderInstance(final String className, final Object[] params) throws ClassNotFoundException,

--- a/src/test/java/org/fluentd/logger/TestBugfixes.java
+++ b/src/test/java/org/fluentd/logger/TestBugfixes.java
@@ -1,0 +1,31 @@
+package org.fluentd.logger;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class TestBugfixes {
+	/** Prior to the issue fix, this test fails with an NPE on the last line.
+	 */
+	@Test
+	public void validLoggerReturned_whenOpenThenCloseThenOpenWithSameParameters() {
+		// use test sender so we don't need to have an actual fluentd running...
+		System.setProperty(Config.FLUENT_SENDER_CLASS, "org.fluentd.logger.sender.NullSender");		
+		FluentLogger logger = FluentLogger.getLogger("test");
+
+		// this works
+		logger.log("tag", Collections.<String, Object>emptyMap());
+		
+		// now close it; sender is closed and set to null	
+		logger.close();
+		assertEquals(null, logger.sender);
+		
+		// get another logger with the exact same parameters; we'd expect this to work, yes?
+		FluentLogger logger2 = FluentLogger.getLogger("test");
+
+		// let's see if it does
+		logger2.log("tag", Collections.<String, Object>emptyMap());
+	}
+}


### PR DESCRIPTION
Encountered issue #64 when trying to use 0.3.3 with a Spring Boot application. Root cause is that after a logger is closed, it is retained in the factory cache. A request to a logger with identical parameters will return the invalid logger. (For whatever reason, Spring Boot performs this sequence of operations.) There also appears to be no way to re-establish a sender after a logger is closed.

This patch fixes the problem by purging loggers from the factory cache when they are closed.