### PR TITLE
Not to log class name

### DIFF
--- a/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
+++ b/src/main/java/org/fluentd/logger/sender/RawSocketSender.java
@@ -203,7 +203,7 @@ public class RawSocketSender implements Sender {
             catch (Exception handlerException) {
                 LOG.warn("ErrorHandler.handleNetworkError failed", handlerException);
             }
-            LOG.error(this.getClass().getName(), "flush", e);
+            LOG.error("flush failed", e);
             reconnector.addErrorHistory(System.currentTimeMillis());
             close();
         }


### PR DESCRIPTION
Now, the log message contains the class name:
  2021-12-19 22:59:31,787 ERROR [main] org.fluentd.logger.sender.RawSocketSender
  java.net.ConnectException: Connection refused (Connection refused)

Since log frameworks usually have a way to log class name without the
need to include it in the log message, the class name should be removed.
The following text shows a sample log mesage after this change:

  2021-12-19 22:56:58,842 ERROR [main] flush failed
  java.net.ConnectException: Connection refused (Connection refused)