### PR TITLE
Reducing the chance of flaky test failure

### DIFF
--- a/src/test/java/org/fluentd/logger/TestFluentLogger.java
+++ b/src/test/java/org/fluentd/logger/TestFluentLogger.java
@@ -442,7 +442,7 @@ public class TestFluentLogger {
                 }
             });
         }
-        Thread.sleep(1000);
+        Thread.sleep(4000);
         executorService.shutdown();
         executorService.awaitTermination(300, TimeUnit.SECONDS);
 


### PR DESCRIPTION
**Description:**
This test is flakily fails. I run this test many times and it makes assertion fails.

I was running this test many times and it fails. The failure message is as follows.

**Failure:**
Running org.fluentd.logger.TestFluentLogger
2023-03-31 10:11:42,340 DEBUG [pool-2-thread-1] Started MockFluentd port:33845
Exception in thread "pool-3-thread-15" java.lang.NullPointerException
    at org.fluentd.logger.FluentLogger.log(FluentLogger.java:101)
    at org.fluentd.logger.FluentLogger.log(FluentLogger.java:86)
    at org.fluentd.logger.TestFluentLogger$7.run(TestFluentLogger.java:436)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
java.lang.NullPointerException
    at org.fluentd.logger.FluentLogger.log(FluentLogger.java:101)
    at org.fluentd.logger.FluentLogger.log(FluentLogger.java:86)
    at org.fluentd.logger.TestFluentLogger$7.run(TestFluentLogger.java:436)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
Exception in thread "pool-3-thread-7" java.lang.NullPointerException
    at org.fluentd.logger.FluentLogger.log(FluentLogger.java:101)
    at org.fluentd.logger.FluentLogger.log(FluentLogger.java:86)
    at org.fluentd.logger.TestFluentLogger$7.run(TestFluentLogger.java:436)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
Exception in thread "pool-3-thread-10" java.lang.NullPointerException
    at org.fluentd.logger.FluentLogger.log(FluentLogger.java:101)
    at org.fluentd.logger.FluentLogger.log(FluentLogger.java:86)
    at org.fluentd.logger.TestFluentLogger$7.run(TestFluentLogger.java:436)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
2023-03-31 10:16:50,774 ERROR [main] Timed out
2023-03-31 10:16:50,774 DEBUG [pool-2-thread-1] Terminated MockFluentd port:33845
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 308.585 sec <<< FAILURE!

Results :

Failed tests: 
  testInMultiThreading(org.fluentd.logger.TestFluentLogger): expected:<210000> but was:<209591>

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0