### PR TITLE
Fix Test Flakiness

### DIFF
--- a/src/test/java/org/fluentd/logger/TestFluentLogger.java
+++ b/src/test/java/org/fluentd/logger/TestFluentLogger.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.*;
 
 public class TestFluentLogger {
-    private static boolean hasExecuted = false;
+    private static volatile boolean hasExecuted = false;
     private Logger _logger = LoggerFactory.getLogger(TestFluentLogger.class);
 
     class FixedThreadManager {
@@ -444,7 +444,7 @@ public class TestFluentLogger {
                 }
             });
         }
-        while(!hasExecuted) { 
+        while (!hasExecuted) { 
             Thread.yield(); 
         }
         Thread.sleep(1000);

--- a/src/test/java/org/fluentd/logger/TestFluentLogger.java
+++ b/src/test/java/org/fluentd/logger/TestFluentLogger.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.*;
 
 public class TestFluentLogger {
+    private static boolean hasExecuted = false;
     private Logger _logger = LoggerFactory.getLogger(TestFluentLogger.class);
 
     class FixedThreadManager {
@@ -439,8 +440,12 @@ public class TestFluentLogger {
                             logger.flush();
                     }
                     logger.flush();
+                    hasExecuted = true;
                 }
             });
+        }
+        while(!hasExecuted) { 
+            Thread.yield(); 
         }
         Thread.sleep(1000);
         executorService.shutdown();


### PR DESCRIPTION
### Description:
I observed a previous suggested fix injected some delay to fix the flaky test, but I believe that fix might be unstable in a CI environment or when run on different machines, given the dependency on some constant wait time. I suggest a new way to fix the test by adding some synchronization for the test execution only. I at first identify the source code location whose slow execution (from Line 436 to 442) leads to the flaky test failure. Hence, I introduce one variable in this test class  that is only there to provide some synchronization. Basically, until these statements are executed, I force the thread that shuts down the services. The waiting location is at Line 447 of this test class.

### Failure:
Running org.fluentd.logger.TestFluentLogger
2023-03-31 10:11:42,340 DEBUG [pool-2-thread-1] Started MockFluentd port:33845
Exception in thread "pool-3-thread-15" java.lang.NullPointerException
at org.fluentd.logger.FluentLogger.log(FluentLogger.java:101)
at org.fluentd.logger.FluentLogger.log(FluentLogger.java:86)
at org.fluentd.logger.TestFluentLogger$7.run(TestFluentLogger.java:436)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:829)
java.lang.NullPointerException
at org.fluentd.logger.FluentLogger.log(FluentLogger.java:101)
at org.fluentd.logger.FluentLogger.log(FluentLogger.java:86)
at org.fluentd.logger.TestFluentLogger$7.run(TestFluentLogger.java:436)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:829)
Exception in thread "pool-3-thread-7" java.lang.NullPointerException
at org.fluentd.logger.FluentLogger.log(FluentLogger.java:101)
at org.fluentd.logger.FluentLogger.log(FluentLogger.java:86)
at org.fluentd.logger.TestFluentLogger$7.run(TestFluentLogger.java:436)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:829)
Exception in thread "pool-3-thread-10" java.lang.NullPointerException
at org.fluentd.logger.FluentLogger.log(FluentLogger.java:101)
at org.fluentd.logger.FluentLogger.log(FluentLogger.java:86)
at org.fluentd.logger.TestFluentLogger$7.run(TestFluentLogger.java:436)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:829)
2023-03-31 10:16:50,774 ERROR [main] Timed out
2023-03-31 10:16:50,774 DEBUG [pool-2-thread-1] Terminated MockFluentd port:33845
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 308.585 sec <<< FAILURE!

### Results :

Failed tests:
testInMultiThreading(org.fluentd.logger.TestFluentLogger): expected:<210000> but was:<209591>

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0